### PR TITLE
[System Map] Prevent system-map src and dep to go in built jar (solution build.gradle)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ bin/
 
 generated/
 **/website/src/assets/
+
+# angular
+.angular/cache/
+node_modules/

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -21,4 +21,11 @@ jar {
 tasks.withType(AbstractArchiveTask).configureEach {
 	preserveFileTimestamps = false
 	reproducibleFileOrder = true
+	excludes=[
+		"**/website/.angular",
+		"**/website/node_modules",
+		"**/website/src",
+		"**/website/*.*",
+	]
 }
+


### PR DESCRIPTION
Update build.gradle to exclude unecessary website files for release:
- node_modules
- src
- .angular
- files directly in website folder

The actual drawback is that website development is not isolated from gradle and so build.gradle need maintenance if new folders are added in website.
