### PR TITLE
Use constant-time circular timetable arithmetic

### DIFF
--- a/src/main/java/org/mtr/core/tool/Utilities.java
+++ b/src/main/java/org/mtr/core/tool/Utilities.java
@@ -220,35 +220,89 @@ public interface Utilities {
 	}
 
 	static long circularClamp(long value, long min, long max, long totalDegrees) {
-		long result = value;
-		while (result < min) {
-			result += totalDegrees;
+		if (value >= min && value <= max) {
+			return value;
 		}
-		while (result > max) {
-			result -= totalDegrees;
+		if (totalDegrees <= 0) {
+			throw new IllegalArgumentException("The circular range must be positive");
 		}
-		return result;
+
+		final long valueRemainder = Math.floorMod(value, totalDegrees);
+		if (value < min) {
+			long offset = valueRemainder - Math.floorMod(min, totalDegrees);
+			if (offset < 0) {
+				offset += totalDegrees;
+			}
+			return min + offset;
+		} else {
+			long offset = Math.floorMod(max, totalDegrees) - valueRemainder;
+			if (offset < 0) {
+				offset += totalDegrees;
+			}
+			return max - offset;
+		}
 	}
 
 	static double circularClamp(double value, double min, double max, double totalDegrees) {
-		double result = value;
-		while (result < min) {
-			result += totalDegrees;
+		if (value >= min && value <= max || Double.isNaN(value)) {
+			return value;
 		}
-		while (result > max) {
-			result -= totalDegrees;
+		if (!(totalDegrees > 0) || !Double.isFinite(totalDegrees)) {
+			throw new IllegalArgumentException("The circular range must be finite and positive");
 		}
-		return result;
+
+		if (value < min) {
+			return min + floorMod(value - min, totalDegrees);
+		} else {
+			return max - floorMod(max - value, totalDegrees);
+		}
+	}
+
+	private static double floorMod(double value, double modulus) {
+		final double remainder = value % modulus;
+		return remainder < 0 ? remainder + modulus : remainder;
 	}
 
 	static long circularDifference(long value1, long value2, long totalDegrees) {
+		if (value1 == value2) {
+			return 0;
+		}
+		if (totalDegrees <= 0) {
+			throw new IllegalArgumentException("The circular range must be positive");
+		}
+
 		final long halfTotalDegrees = totalDegrees / 2;
-		return value1 - circularClamp(value2, value1 - halfTotalDegrees, value1 + halfTotalDegrees, totalDegrees);
+		long difference = Math.floorMod(value1, totalDegrees) - Math.floorMod(value2, totalDegrees);
+		if (difference > halfTotalDegrees) {
+			difference -= totalDegrees;
+		} else if (difference < -halfTotalDegrees) {
+			difference += totalDegrees;
+		}
+		if ((totalDegrees & 1) == 0 && Math.abs(difference) == halfTotalDegrees) {
+			return value1 > value2 ? halfTotalDegrees : -halfTotalDegrees;
+		}
+		return difference;
 	}
 
 	static double circularDifference(double value1, double value2, double totalDegrees) {
+		if (value1 == value2) {
+			return 0;
+		}
+		if (!(totalDegrees > 0) || !Double.isFinite(totalDegrees)) {
+			throw new IllegalArgumentException("The circular range must be finite and positive");
+		}
+
 		final double halfTotalDegrees = totalDegrees / 2;
-		return value1 - circularClamp(value2, value1 - halfTotalDegrees, value1 + halfTotalDegrees, totalDegrees);
+		double difference = floorMod(value1, totalDegrees) - floorMod(value2, totalDegrees);
+		if (difference > halfTotalDegrees) {
+			difference -= totalDegrees;
+		} else if (difference < -halfTotalDegrees) {
+			difference += totalDegrees;
+		}
+		if (Math.abs(difference) == halfTotalDegrees) {
+			return value1 > value2 ? halfTotalDegrees : -halfTotalDegrees;
+		}
+		return difference;
 	}
 
 	static int compare(long value1, long value2, IntSupplier ifZero) {

--- a/src/test/java/org/mtr/core/tool/UtilitiesTests.java
+++ b/src/test/java/org/mtr/core/tool/UtilitiesTests.java
@@ -107,18 +107,50 @@ public final class UtilitiesTests {
 	public void testCircularClamp() {
 		assertEquals(350, Utilities.circularClamp(350, 0, 360, 360));
 		assertEquals(10, Utilities.circularClamp(370, 0, 360, 360));
+		assertEquals(0, Utilities.circularClamp(-360, 0, 360, 360));
+		assertEquals(360, Utilities.circularClamp(720, 0, 360, 360));
+		assertEquals(352, Utilities.circularClamp(Long.MIN_VALUE, 0, 360, 360));
+		assertEquals(7, Utilities.circularClamp(Long.MAX_VALUE, 0, 360, 360));
+		assertThrows(IllegalArgumentException.class, () -> Utilities.circularClamp(1, 0, 0, 0));
+	}
+
+	@Test
+	public void testCircularClampMatchesIterativeSemantics() {
+		for (long value = -2000; value <= 2000; value++) {
+			assertEquals(iterativeCircularClamp(value, -180, 180, 360), Utilities.circularClamp(value, -180, 180, 360));
+			assertEquals(iterativeCircularClamp(value, 100, 460, 360), Utilities.circularClamp(value, 100, 460, 360));
+		}
 	}
 
 	@Test
 	public void testCircularClampDouble() {
 		assertEquals(350.0, Utilities.circularClamp(350.0, 0.0, 360.0, 360.0), 1e-10);
 		assertEquals(10.0, Utilities.circularClamp(370.0, 0.0, 360.0, 360.0), 1e-10);
+		assertEquals(0.0, Utilities.circularClamp(-360.0, 0.0, 360.0, 360.0), 1e-10);
+		assertEquals(360.0, Utilities.circularClamp(720.0, 0.0, 360.0, 360.0), 1e-10);
+		assertTrue(Double.isNaN(Utilities.circularClamp(Double.NaN, 0.0, 360.0, 360.0)));
+		assertThrows(IllegalArgumentException.class, () -> Utilities.circularClamp(1.0, 0.0, 0.0, 0.0));
 	}
 
 	@Test
 	public void testCircularDifference() {
 		assertEquals(10, Utilities.circularDifference(10, 0, 360));
 		assertEquals(-10, Utilities.circularDifference(0, 10, 360));
+		assertEquals(180, Utilities.circularDifference(180, 0, 360));
+		assertEquals(-180, Utilities.circularDifference(0, 180, 360));
+		assertEquals(-30400000, Utilities.circularDifference(0, 1753000000000L, 86400000));
+		assertEquals(15, Utilities.circularDifference(Long.MAX_VALUE, Long.MIN_VALUE, 360));
+		assertEquals(0, Utilities.circularDifference(1, 1, 0));
+		assertThrows(IllegalArgumentException.class, () -> Utilities.circularDifference(1, 2, 0));
+	}
+
+	@Test
+	public void testCircularDifferenceMatchesIterativeSemantics() {
+		for (long value1 = -720; value1 <= 720; value1++) {
+			for (long value2 = -720; value2 <= 720; value2++) {
+				assertEquals(iterativeCircularDifference(value1, value2, 360), Utilities.circularDifference(value1, value2, 360));
+			}
+		}
 	}
 
 	@Test
@@ -140,5 +172,21 @@ public final class UtilitiesTests {
 	@Test
 	public void testParseJson() {
 		assertNotNull(Utilities.parseJson("{\"key\":\"value\"}"));
+	}
+
+	private static long iterativeCircularClamp(long value, long min, long max, long period) {
+		long result = value;
+		while (result < min) {
+			result += period;
+		}
+		while (result > max) {
+			result -= period;
+		}
+		return result;
+	}
+
+	private static long iterativeCircularDifference(long value1, long value2, long period) {
+		final long halfPeriod = period / 2;
+		return value1 - iterativeCircularClamp(value2, value1 - halfPeriod, value1 + halfPeriod, period);
 	}
 }


### PR DESCRIPTION
### Summary

Replace iterative circular clamp/difference normalization with constant-time floor-mod arithmetic.

### Problem

The existing helpers repeatedly add or subtract one period until a value reaches the requested window. Runtime is O(abs(offset) / period), so very large timetable offsets or persisted timestamps can monopolize the simulation thread. Extreme long values can also overflow while the loop is normalizing.

### Change

- Normalize integral values with `Math.floorMod`.
- Normalize floating-point values with a floor-mod helper.
- Preserve the existing half-period tie direction.
- Reject non-positive periods instead of entering a non-terminating loop.
- Preserve NaN propagation for doubles.
- Add equivalence tests against the previous iterative semantics over representative ranges plus Long.MIN_VALUE/Long.MAX_VALUE cases.

Runtime becomes O(1) for all finite input magnitudes.

### Validation

- `./gradlew test --no-daemon`
- Full suite passed (113 tests).

Part of #32.