### PR TITLE
Bound simulation catch-up and apply departure backpressure

### DIFF
--- a/src/main/java/org/mtr/core/data/Siding.java
+++ b/src/main/java/org/mtr/core/data/Siding.java
@@ -347,7 +347,7 @@ public final class Siding extends SidingSchema implements Utilities {
 								log.debug("Already deployed vehicle from {} for departure index {}", getDepotName(), departureIndex);
 							}
 						} else {
-							vehicle.startUp(departureIndex, departures.getLong(departureIndex));
+							vehicle.tryStartUp(departureIndex, departures.getLong(departureIndex), vehiclePositions);
 						}
 					}
 				}

--- a/src/main/java/org/mtr/core/data/Vehicle.java
+++ b/src/main/java/org/mtr/core/data/Vehicle.java
@@ -111,6 +111,14 @@ public class Vehicle extends VehicleSchema implements Utilities {
 		return !getIsOnRoute() || railProgress < vehicleExtraData.getTotalVehicleLength() + vehicleExtraData.getRailLength();
 	}
 
+	/**
+	 * Keep jam age stable when the simulator deliberately skips wall-clock time after exhausting its
+	 * catch-up budget. Otherwise scheduler load shedding alone could report every vehicle as jammed.
+	 */
+	public void skipSimulationTime(long skippedMillis) {
+		lastMovementMillis += skippedMillis;
+	}
+
 	public void initVehiclePositions(Object2ObjectAVLTreeMap<Position, Object2ObjectAVLTreeMap<Position, VehiclePosition>> vehiclePositions) {
 		writeVehiclePositions(Utilities.getIndexFromConditionalList(vehicleExtraData.immutablePath, railProgress), vehiclePositions);
 	}
@@ -211,6 +219,50 @@ public class Vehicle extends VehicleSchema implements Utilities {
 				deviationSpeedAdjustment = 1;
 			}
 		}
+	}
+
+	/**
+	 * Attempt to dispatch this vehicle from its siding without adding another train to an already
+	 * occupied or jammed route. A successful dispatch is written into the current occupancy snapshot
+	 * immediately so another siding evaluated later in the same simulation tick can observe it.
+	 *
+	 * @return whether the vehicle was dispatched
+	 */
+	public boolean tryStartUp(long newDepartureIndex, long newSidingDepartureTime, @Nullable ObjectArrayList<Object2ObjectAVLTreeMap<Position, Object2ObjectAVLTreeMap<Position, VehiclePosition>>> vehiclePositions) {
+		vehicleExtraData.closeDoors();
+
+		if (isDeploymentBlocked(vehiclePositions)) {
+			return false;
+		}
+
+		startUp(newDepartureIndex, newSidingDepartureTime);
+		if (!getIsOnRoute()) {
+			return false;
+		}
+
+		if (vehiclePositions != null && vehiclePositions.size() > 1) {
+			writeVehiclePositions(Utilities.getIndexFromConditionalList(vehicleExtraData.immutablePath, railProgress), vehiclePositions.get(1));
+		}
+		return true;
+	}
+
+	private boolean isDeploymentBlocked(@Nullable ObjectArrayList<Object2ObjectAVLTreeMap<Position, Object2ObjectAVLTreeMap<Position, VehiclePosition>>> vehiclePositions) {
+		if (data instanceof final Simulator simulator && (
+			simulator.isRouteJammed(vehicleExtraData.getPreviousRouteId()) ||
+				simulator.isRouteJammed(vehicleExtraData.getThisRouteId()) ||
+				simulator.isRouteJammed(vehicleExtraData.getNextRouteId())
+		)) {
+			return true;
+		}
+
+		if (vehiclePositions == null || vehiclePositions.size() < 2 || vehicleExtraData.immutablePath.isEmpty()) {
+			return false;
+		}
+
+		final double deploymentProgress = vehicleExtraData.getDefaultPosition() + Siding.ACCELERATION_DEFAULT;
+		final int currentIndex = Utilities.getIndexFromConditionalList(vehicleExtraData.immutablePath, deploymentProgress);
+		final double deploymentClearance = vehicleExtraData.getTotalVehicleLength() + transportMode.stoppingSpace;
+		return currentIndex >= 0 && railBlockedDistance(currentIndex, deploymentProgress, deploymentClearance, vehiclePositions, true, false) >= 0;
 	}
 
 	public long getDepartureIndex() {
@@ -583,7 +635,7 @@ public class Vehicle extends VehicleSchema implements Utilities {
 			if (!transportMode.continuousMovement) {
 				final DoubleDoubleImmutablePair blockedBounds = getBlockedBounds(pathData, railProgress - vehicleExtraData.getTotalVehicleLength(), railProgress - 0.01);
 				if (blockedBounds.rightDouble() - blockedBounds.leftDouble() > 0.01) {
-					if (getIsOnRoute() && index > 0) {
+					if (getIsOnRoute() && index >= 0) {
 						Data.put(vehiclePositions, position1, position2, vehiclePosition -> {
 							final VehiclePosition newVehiclePosition = vehiclePosition == null ? new VehiclePosition() : vehiclePosition;
 							newVehiclePosition.addSegment(blockedBounds.leftDouble(), blockedBounds.rightDouble(), id);

--- a/src/main/java/org/mtr/core/simulation/Simulator.java
+++ b/src/main/java/org/mtr/core/simulation/Simulator.java
@@ -86,6 +86,7 @@ public class Simulator extends Data implements Utilities {
 	private final MessageQueue<QueueObject> messageQueueC2S = new MessageQueue<>();
 	private final MessageQueue<QueueObject> messageQueueS2C = new MessageQueue<>();
 	private final LongOpenHashSet jammedRouteIds = new LongOpenHashSet();
+	private final LongOpenHashSet previouslyJammedRouteIds = new LongOpenHashSet();
 
 	/**
 	 * If the simulation falls more than this many milliseconds behind wall clock, log a notice and
@@ -93,6 +94,7 @@ public class Simulator extends Data implements Utilities {
 	 * "noisy log on a sluggish host" and "silent multi-hour drift".
 	 */
 	private static final int SIMULATION_DIFFERENCE_LOGGING_THRESHOLD = 120000;
+	private static final int MAX_CATCH_UP_TICKS = 5;
 	private static final int MAX_PASSENGER_DIRECTIONS_REQUESTS = 512;
 	/**
 	 * Default in-game day length in real-time milliseconds (20 in-game minutes).
@@ -168,16 +170,15 @@ public class Simulator extends Data implements Utilities {
 
 	/**
 	 * Catch the simulation up to wall clock and log a notice if it had drifted by more than
-	 * {@link #SIMULATION_DIFFERENCE_LOGGING_THRESHOLD} milliseconds. If the drift exceeds an hour
-	 * the simulator jumps to "one hour ago" instead of replaying the full gap, since replaying
-	 * many hours of vehicle motion is rarely useful and is expensive.
+	 * {@link #SIMULATION_DIFFERENCE_LOGGING_THRESHOLD} milliseconds. If the drift exceeds an hour,
+	 * deployed vehicles are cleared and only the bounded catch-up window is replayed.
 	 */
 	public void tick() {
 		final long totalDifference = System.currentTimeMillis() - getCurrentMillis();
 		if (totalDifference >= SIMULATION_DIFFERENCE_LOGGING_THRESHOLD) {
 			if (totalDifference > MILLIS_PER_HOUR) {
-				// If the simulation is over an hour behind, jump to one hour ago and simulate the last hour
-				setCurrentMillis(System.currentTimeMillis() - MILLIS_PER_HOUR);
+				// Replaying an hour synchronously can permanently trap an overloaded simulation worker.
+				setCurrentMillis(System.currentTimeMillis() - (long) MAX_CATCH_UP_TICKS * MILLIS_PER_SECOND);
 				sidings.forEach(Siding::clearVehicles);
 			}
 			final ObjectLongImmutablePair<Integer> ticksAndDuration = Utilities.measureDuration(this::tickUntilCaughtUp);
@@ -389,7 +390,7 @@ public class Simulator extends Data implements Utilities {
 	 * @return whether the route is currently considered jammed for pathfinding purposes.
 	 */
 	public boolean isRouteJammed(long routeId) {
-		return routeId != 0 && jammedRouteIds.contains(routeId);
+		return routeId != 0 && (jammedRouteIds.contains(routeId) || previouslyJammedRouteIds.contains(routeId));
 	}
 
 	/**
@@ -421,22 +422,35 @@ public class Simulator extends Data implements Utilities {
 	}
 
 	/**
-	 * Simulates the system in one-second intervals until the simulation is all caught up
+	 * Simulates the system in one-second intervals until caught up, subject to a bounded work budget.
+	 * If simulation work itself is slower than wall clock, remaining elapsed time is skipped instead
+	 * of trapping the scheduler in an unbounded catch-up loop.
 	 *
 	 * @return the number of ticks it took
 	 */
 	private int tickUntilCaughtUp() {
 		int ticks = 0;
-		while (true) {
+		while (ticks < MAX_CATCH_UP_TICKS) {
 			ticks++;
 			final long totalDifference = System.currentTimeMillis() - getCurrentMillis();
 			if (totalDifference > MILLIS_PER_SECOND) {
 				tick(MILLIS_PER_SECOND);
 			} else {
-				tick(totalDifference);
+				tick(Math.max(0, totalDifference));
 				return ticks;
 			}
 		}
+
+		final long currentWallTime = System.currentTimeMillis();
+		final long skippedMillis = currentWallTime - getCurrentMillis();
+		if (skippedMillis > MILLIS_PER_SECOND) {
+			sidings.forEach(siding -> siding.iterateVehicles(vehicle -> vehicle.skipSimulationTime(skippedMillis)));
+			lastMillis = currentWallTime;
+			setCurrentMillis(currentWallTime);
+			log.warn("Simulation {} skipped {}ms after reaching the {}-tick catch-up budget", dimension, skippedMillis, MAX_CATCH_UP_TICKS);
+		}
+
+		return ticks;
 	}
 
 	/**
@@ -467,6 +481,11 @@ public class Simulator extends Data implements Utilities {
 				sync();
 			}
 
+			// Preserve the previous tick's result while sidings are simulated. Without this one-tick
+			// hand-off, a depot that happens to be iterated before the stalled train cannot observe the
+			// congestion and may dispatch another vehicle into the same route.
+			previouslyJammedRouteIds.clear();
+			previouslyJammedRouteIds.addAll(jammedRouteIds);
 			jammedRouteIds.clear();
 			sidings.forEach(siding -> siding.simulateVehicles(millisElapsed, vehiclePositions.get(siding.getTransportModeOrdinal())));
 			clients.forEach(client -> client.sendUpdates(this));

--- a/src/test/java/org/mtr/core/data/PassengerTests.java
+++ b/src/test/java/org/mtr/core/data/PassengerTests.java
@@ -78,12 +78,14 @@ public final class PassengerTests {
 	}
 
 	@Test
-	public void testMarkAndClearRouteJammed() {
+	public void testRouteJamSurvivesOneTickHandoff() {
 		simulator.markRouteJammed(42);
 		assertTrue(simulator.isRouteJammed(42), "Route 42 should be jammed after marking");
 		assertFalse(simulator.isRouteJammed(0), "Route 0 should not be affected");
 		simulator.tick();
-		assertFalse(simulator.isRouteJammed(42), "Jammed routes should be cleared after tick");
+		assertTrue(simulator.isRouteJammed(42), "The previous tick should remain visible while sidings dispatch");
+		simulator.tick();
+		assertFalse(simulator.isRouteJammed(42), "An unobserved route jam should expire after one handoff tick");
 	}
 
 	@Test

--- a/src/test/java/org/mtr/core/data/VehicleDeploymentTests.java
+++ b/src/test/java/org/mtr/core/data/VehicleDeploymentTests.java
@@ -1,0 +1,75 @@
+package org.mtr.core.data;
+
+import it.unimi.dsi.fastutil.objects.Object2ObjectAVLTreeMap;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.junit.jupiter.api.Test;
+import org.mtr.core.simulation.Simulator;
+import org.mtr.core.tool.Angle;
+
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public final class VehicleDeploymentTests {
+
+	@Test
+	public void testBlockedDeploymentIsSkipped() {
+		final Vehicle vehicle = createVehicle();
+		final ObjectArrayList<Object2ObjectAVLTreeMap<Position, Object2ObjectAVLTreeMap<Position, VehiclePosition>>> positions = createPositionSnapshots();
+		final PathData pathData = vehicle.vehicleExtraData.immutablePath.getFirst();
+		final VehiclePosition blocker = new VehiclePosition();
+		blocker.addSegment(0, 100, Long.MAX_VALUE);
+		putPosition(positions.getFirst(), pathData, blocker);
+
+		assertFalse(vehicle.tryStartUp(0, 0, positions));
+		assertFalse(vehicle.getIsOnRoute());
+	}
+
+	@Test
+	public void testSuccessfulDeploymentIsImmediatelyReserved() {
+		final Vehicle vehicle = createVehicle();
+		final ObjectArrayList<Object2ObjectAVLTreeMap<Position, Object2ObjectAVLTreeMap<Position, VehiclePosition>>> positions = createPositionSnapshots();
+
+		assertTrue(vehicle.tryStartUp(0, 0, positions));
+		assertTrue(vehicle.getIsOnRoute());
+
+		final PathData pathData = vehicle.vehicleExtraData.immutablePath.getFirst();
+		final VehiclePosition reservation = Data.tryGet(positions.get(1), pathData.getOrderedPosition1(), pathData.getOrderedPosition2());
+		assertNotNull(reservation);
+		assertTrue(reservation.getClosestOverlap(0, 100, pathData.reversePositions, Long.MIN_VALUE) >= 0);
+	}
+
+	private static Vehicle createVehicle() {
+		final Simulator simulator = new Simulator("test", new String[]{"test"}, Paths.get("build/test-data-deployment"), false);
+		final Position start = new Position(0, 0, 0);
+		final Position end = new Position(100, 0, 0);
+		final PathData pathData = new PathData(null, 0, 0, -1, 0, 100, start, Angle.E, end, Angle.E);
+		final ObjectArrayList<PathData> sidingPath = new ObjectArrayList<>();
+		sidingPath.add(pathData);
+		final ObjectArrayList<PathData> emptyPath = new ObjectArrayList<>();
+		final ObjectArrayList<VehicleCar> cars = new ObjectArrayList<>();
+		cars.add(new VehicleCar("test", 10, 2, 100, 0, 5, 0.5, 0.5));
+		final VehicleExtraData extraData = VehicleExtraData.create(
+			0, 0, 10, cars, sidingPath, emptyPath, emptyPath, pathData,
+			false, Siding.ACCELERATION_DEFAULT, Siding.ACCELERATION_DEFAULT, false, 0, 0
+		);
+		final Vehicle vehicle = new Vehicle(extraData, null, TransportMode.TRAIN, simulator);
+		vehicle.simulate(0, null, null);
+		return vehicle;
+	}
+
+	private static ObjectArrayList<Object2ObjectAVLTreeMap<Position, Object2ObjectAVLTreeMap<Position, VehiclePosition>>> createPositionSnapshots() {
+		final ObjectArrayList<Object2ObjectAVLTreeMap<Position, Object2ObjectAVLTreeMap<Position, VehiclePosition>>> positions = new ObjectArrayList<>();
+		positions.add(new Object2ObjectAVLTreeMap<>());
+		positions.add(new Object2ObjectAVLTreeMap<>());
+		return positions;
+	}
+
+	private static void putPosition(Object2ObjectAVLTreeMap<Position, Object2ObjectAVLTreeMap<Position, VehiclePosition>> positions, PathData pathData, VehiclePosition vehiclePosition) {
+		final Object2ObjectAVLTreeMap<Position, VehiclePosition> inner = new Object2ObjectAVLTreeMap<>();
+		inner.put(pathData.getOrderedPosition2(), vehiclePosition);
+		positions.put(pathData.getOrderedPosition1(), inner);
+	}
+}


### PR DESCRIPTION
### Summary

Prevent an overloaded simulation from amplifying its own backlog, and stop depots from dispatching additional vehicles into an already occupied or jammed route.

### Catch-up control

- Limit one scheduler invocation to five one-second simulation slices.
- If the worker is still behind, advance the simulation clock explicitly instead of looping without a bound.
- Shift each active vehicle's last-movement timestamp by the skipped duration so load shedding alone does not create false jam reports.
- For gaps over one hour, retain the existing vehicle clear but replay only the bounded five-second window rather than up to 3,600 slices.
- Emit a warning containing the skipped duration and budget.

This is intentional overload degradation: elapsed service is skipped so the simulation thread can return to its scheduler and recover.

### Departure admission

- Check previous/current/next route jam state before startup.
- Check the current occupancy snapshots for the deployment segment and vehicle clearance.
- Write a successful deployment into the current snapshot immediately, making it visible to later sidings in the same tick.
- Hand jam state across one tick so siding iteration order cannot hide a jam.
- Include the first path segment in occupancy publication (`index >= 0`).

### Validation

- Added blocked-deployment and immediate-reservation tests.
- Updated the route-jam lifecycle test to verify exactly one handoff tick.
- `./gradlew test --no-daemon`
- Full suite passed (113 tests).

Part of #32.